### PR TITLE
feat: Sembunyikan kolom URL untuk pengguna yang tidak login

### DIFF
--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -10,3 +10,4 @@ Di rilis v2511.0.1 berisi perbaikan yang diminta Komunitas Open Desa.
 
 1. [#593](https://github.com/OpenSID/pantau/issues/593) Update package keamanaan.
 2. [#599](https://github.com/OpenSID/pantau/issues/599) Known security vulnerabilities detected.
+3. [#598](https://github.com/OpenSID/pantau/issues/598) Sembunyikan kolom URL untuk pengguna yang tidak login.

--- a/resources/views/laporan/openkab.blade.php
+++ b/resources/views/laporan/openkab.blade.php
@@ -166,7 +166,8 @@
             },
             @endif
             {
-                data: 'url'
+                data: 'url',
+                visible: {!! auth()->check() ? 'true' : 'false' !!},
             },
             {
                 data: 'versi'

--- a/resources/views/laporan/tema-pro.blade.php
+++ b/resources/views/laporan/tema-pro.blade.php
@@ -130,7 +130,8 @@
                 data: 'nama_provinsi',
             },
             {
-                data: 'url_hosting'
+                data: 'url_hosting',
+                visible: {!! auth()->check() ? 'true' : 'false' !!},
             },
             {
                 data: 'tema'

--- a/resources/views/laporan/tema.blade.php
+++ b/resources/views/laporan/tema.blade.php
@@ -165,7 +165,8 @@
                     data: 'nama_provinsi',
                 },
                 {
-                    data: 'url_hosting'
+                    data: 'url_hosting',
+                    visible: {!! auth()->check() ? 'true' : 'false' !!},
                 },
                 {
                     data: 'tema'

--- a/resources/views/opendk/kecamatan.blade.php
+++ b/resources/views/opendk/kecamatan.blade.php
@@ -118,6 +118,7 @@
             {
                  orderable: false,
                 name: 'url',
+                visible: {!! auth()->check() ? 'true' : 'false' !!},
                 data: function (data) {
                         return `<a target="_blank" href="https://${data.url}">https://${data.url}</a>`
                     },

--- a/resources/views/pbb/kecamatan.blade.php
+++ b/resources/views/pbb/kecamatan.blade.php
@@ -122,6 +122,7 @@
             },
             {
                  orderable: false,
+                visible: {!! auth()->check() ? 'true' : 'false' !!},
                 name: 'url',
                 data: function (data) {
                         return `<a target="_blank" href="https://${data.url}">https://${data.url}</a>`

--- a/resources/views/website/opendk.blade.php
+++ b/resources/views/website/opendk.blade.php
@@ -83,7 +83,8 @@
                     data: 'nama_provinsi'
                 },
                 {
-                    data: 'url'
+                    data: 'url',
+                    visible: {!! auth()->check() ? 'true' : 'false' !!},
                 },
                 {
                     data: 'versi'

--- a/resources/views/website/pbb_data.blade.php
+++ b/resources/views/website/pbb_data.blade.php
@@ -84,7 +84,8 @@
                     data: 'nama_provinsi'
                 },
                 {
-                    data: 'url'
+                    data: 'url',
+                    visible: {!! auth()->check() ? 'true' : 'false' !!},
                 },
                 {
                     data: 'versi'


### PR DESCRIPTION
Perbaikan issue https://github.com/OpenSID/pantau/issues/598
Sembunyikan kolom URL untuk pengguna yang tidak login

- Menambahkan properti 'visible' pada kolom URL di 7 view blade
- Kolom URL hanya akan ditampilkan untuk pengguna yang sudah login (auth()->check())
- Berpengaruh pada view: laporan/openkab, laporan/tema, laporan/tema-pro, opendk/kecamatan, pbb/kecamatan, website/opendk, dan website/pbb_data
- Meningkatkan keamanan dengan membatasi akses informasi URL hosting"

Berikut adalah daftar file yang berubah :

1. [`resources/views/laporan/openkab.blade.php`](resources/views/laporan/openkab.blade.php)
2. [`resources/views/laporan/tema-pro.blade.php`](resources/views/laporan/tema-pro.blade.php)
3. [`resources/views/laporan/tema.blade.php`](resources/views/laporan/tema.blade.php)
4. [`resources/views/opendk/kecamatan.blade.php`](resources/views/opendk/kecamatan.blade.php)
5. [`resources/views/pbb/kecamatan.blade.php`](resources/views/pbb/kecamatan.blade.php)
6. [`resources/views/website/opendk.blade.php`](resources/views/website/opendk.blade.php)
7. [`resources/views/website/pbb_data.blade.php`](resources/views/website/pbb_data.blade.php)

Total: 7 file view blade yang diubah dengan menambahkan properti `visible: {!! auth()->check() ? 'true' : 'false' !!}` pada kolom URL untuk menyembunyikannya dari pengguna yang tidak login.

https://github.com/user-attachments/assets/0ccf6cf3-b737-4650-bf80-eddc1e6256a8

