### PR TITLE
Penambahan Halaman PBB Pengguna Aktif

### DIFF
--- a/app/Http/Controllers/PenggunaAktifPbbController.php
+++ b/app/Http/Controllers/PenggunaAktifPbbController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Pbb;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Yajra\DataTables\Facades\DataTables;
+
+class PenggunaAktifPbbController extends Controller
+{
+    public function index(Request $request)
+    {
+        $fillters = [
+            'kode_provinsi' => $request->kode_provinsi,
+            'kode_kabupaten' => $request->kode_kabupaten,
+            'kode_kecamatan' => $request->kode_kecamatan,
+            'akses_opendk' => $request->akses_opendk,
+            'versi_opendk' => $request->versi_opendk,
+        ];
+
+        if ($request->ajax()) {
+            $_30HariLalu = Carbon::now()->subDays(30);
+
+            $query = Pbb::wilayahkhusus()
+                ->where('updated_at', '>=', $_30HariLalu)
+                ->filterDatatable($fillters)
+                ->select([
+                    'id',
+                    'nama_desa',
+                    'nama_kecamatan',
+                    'nama_kabupaten',
+                    'nama_provinsi',
+                    'versi',
+                    'updated_at',
+                ]);
+
+            return DataTables::of($query)
+                ->addIndexColumn()
+                ->addColumn('akses_terakhir', function ($data) {
+                    return $data->updated_at ? $data->updated_at->format('Y-m-d H:i:s') : '-';
+                })
+                ->make(true);
+        }
+
+        return view('pbb.pengguna_aktif', compact('fillters'));
+    }
+}

--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -2,6 +2,7 @@ Di rilis v2601.0.0 berisi perbaikan yang diminta Komunitas Open Desa.
 
 #### Penambahan Fitur
 
+1. [#620](https://github.com/OpenSID/pantau/issues/620) Penambahan halaman PBB Pengguna Aktif.
 
 #### Perbaikan Bug
 

--- a/database/factories/PbbFactory.php
+++ b/database/factories/PbbFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Pbb;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PbbFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Pbb::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'kode_desa' => $this->faker->numerify('##.##.##.####'),
+            'nama_desa' => $this->faker->city,
+            'kode_kecamatan' => $this->faker->numerify('##.##.##'),
+            'nama_kecamatan' => $this->faker->city,
+            'kode_kabupaten' => $this->faker->numerify('##.##'),
+            'nama_kabupaten' => $this->faker->city,
+            'kode_provinsi' => $this->faker->numerify('##'),
+            'nama_provinsi' => $this->faker->state,
+            'versi' => $this->faker->randomElement(['1.0.0', '1.1.0', '2.0.0']),
+            'updated_at' => now(),
+            'created_at' => now(),
+        ];
+    }
+}

--- a/resources/views/pbb/pengguna_aktif.blade.php
+++ b/resources/views/pbb/pengguna_aktif.blade.php
@@ -1,0 +1,130 @@
+@extends('layouts.index')
+@include('layouts.components.select2_wilayah')
+
+@section('title', 'PBB Pengguna Aktif')
+
+@section('content_header')
+<h1>
+    PBB Pengguna Aktif<small
+        class="font-weight-light ml-1 text-md font-weight-bold">@if ($provinsi = session('provinsi'))
+            | {{ $provinsi->nama_prov ?? $provinsi }}
+        @endif
+    </small></h1>
+@stop
+
+@section('content')
+    @include('layouts.components.notification')
+    <div class="row">
+        <div class="col-lg-12">
+
+            <div class="card card-outline card-primary">
+                <div class="card-header">
+                    <div class="row">
+                        <div class="col-sm-3">
+                            <a class="btn btn-sm btn-secondary" data-toggle="collapse" href="#collapse-filter" role="button"
+                                aria-expanded="false" aria-controls="collapse-filter">
+                                <i class="fas fa-filter"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-md-12">
+                            @include('layouts.components.form_filter')
+                        </div>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table" id="table-pbb-pengguna-aktif">
+                            <thead>
+                                <tr>
+                                    <th>No</th>
+                                    <th>Nama Desa</th>
+                                    <th>Kecamatan</th>
+                                    <th>Kabupaten</th>
+                                    <th>Provinsi</th>
+                                    <th>Versi</th>
+                                    <th>Akses Terakhir</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                    <!-- /.table-responsive -->
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@section('js')
+    <script>
+        const params = new URLSearchParams(window.location.search);
+
+        var pbbPenggunaAktif = $('#table-pbb-pengguna-aktif').DataTable({
+            processing: true,
+            serverSide: true,
+            autoWidth: false,
+            ordering: true,
+
+            ajax: {
+                url: `{{ url('pbb/pengguna-aktif') }}`,
+                method: 'get',
+                data: function (data) {
+                    data.kode_provinsi = $('#provinsi').val() ? $('#provinsi').val() : params.get(
+                        'kode_provinsi');
+                    data.kode_kabupaten = $('#kabupaten').val() ? $('#kabupaten').val() : params.get(
+                        'kode_kabupaten');
+                    data.kode_kecamatan = $('#kecamatan').val();
+                    // filter pbb might use different param names if needed, 
+                    // but following opendk pattern for now
+                    data.akses_opendk = $('#akses_opendk').val();
+                    data.versi_opendk = $('#versi_opendk').val();
+                }
+            },
+            columns: [{
+                data: 'DT_RowIndex',
+                name: 'DT_RowIndex',
+                searchable: false,
+                orderable: false
+            },
+            {
+                data: 'nama_desa'
+            },
+            {
+                data: 'nama_kecamatan'
+            },
+            {
+                data: 'nama_kabupaten'
+            },
+            {
+                data: 'nama_provinsi'
+            },
+            {
+                data: 'versi'
+            },
+            {
+                data: 'akses_terakhir',
+                orderable: true
+            }],
+            order: [
+                [6, 'desc']
+            ],
+        });
+
+        $('#filter').on('click', function (e) {
+            pbbPenggunaAktif.draw();
+        });
+
+        $(document).on('click', '#reset', function (e) {
+            e.preventDefault();
+            $('#provinsi').val('').change();
+            $('#kabupaten').val('').change();
+            $('#kecamatan').val('').change();
+            $('#akses_opendk').val('').change();
+            $('#versi_opendk').val('').change();
+
+            pbbPenggunaAktif.ajax.reload();
+        });
+    </script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,7 @@ use App\Http\Controllers\LaporanTemaProController;
 use App\Http\Controllers\OpenDKDashboardController;
 use App\Http\Controllers\LaporanDesaAktifController;
 use App\Http\Controllers\KecamatanAktifOpendkController;
+use App\Http\Controllers\PenggunaAktifPbbController;
 use App\Http\Controllers\OpenKabDashboardController;
 use App\Http\Controllers\WebsiteDashboardController;
 use App\Http\Controllers\Admin\Wilayah\DesaController;
@@ -68,7 +69,7 @@ Route::group(['middleware' => 'web.dashboard'], function () {
         Route::get('opensid', [WebsiteDashboardController::class, 'opensid']);
         Route::get('opensid/versi', [WebsiteDashboardController::class, 'opensid_versi']);
         Route::get('opensid/versi/detail', [WebsiteDashboardController::class, 'opensid_versi_detail']);
-        Route::get('opensid/peta', [PetaPeriodController::class, 'index']);        
+        Route::get('opensid/peta', [PetaPeriodController::class, 'index']);
         Route::get('opensid-data', [WebsiteDashboardController::class, 'opensidData']);
         Route::get('pbb-data', [WebsiteDashboardController::class, 'pbbData']);
         Route::get('openkab-data', [WebsiteDashboardController::class, 'openkabData']);
@@ -163,6 +164,7 @@ Route::prefix('pbb')
         Route::delete('desa/{desa}', [PbbController::class, 'deleteDesa'])->middleware('auth');
         Route::get('kabupaten', [PbbController::class, 'kabupaten']);
         Route::get('versi', [PbbController::class, 'versi']);
+        Route::get('pengguna-aktif', [PenggunaAktifPbbController::class, 'index']);
     });
 
 Route::prefix('mobile')

--- a/tests/Feature/PenggunaAktifPbbTest.php
+++ b/tests/Feature/PenggunaAktifPbbTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Pbb;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Carbon\Carbon;
+
+class PenggunaAktifPbbTest extends TestCase
+{
+    use WithFaker;
+
+    /**
+     * Test halaman pengguna aktif PBB dapat diakses oleh user yang sudah login.
+     *
+     * @return void
+     */
+    public function test_pengguna_aktif_pbb_page_can_be_accessed_by_authenticated_user()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->get('/pbb/pengguna-aktif');
+
+        $response->assertStatus(200);
+        $response->assertViewIs('pbb.pengguna_aktif');
+        $response->assertViewHas('fillters');
+        $response->assertSee('PBB Pengguna Aktif');
+        $response->assertSee('table-pbb-pengguna-aktif');
+    }
+
+    /**
+     * Test halaman pengguna aktif PBB dapat diakses tanpa login.
+     *
+     * @return void
+     */
+    public function test_pengguna_aktif_pbb_page_can_be_accessed_without_authentication()
+    {
+        $response = $this->get('/pbb/pengguna-aktif');
+
+        $response->assertStatus(200);
+        $response->assertViewIs('pbb.pengguna_aktif');
+        $response->assertSee('PBB Pengguna Aktif');
+    }
+
+    /**
+     * Test AJAX request untuk data pengguna aktif PBB.
+     *
+     * @return void
+     */
+    public function test_pengguna_aktif_pbb_ajax_request_returns_json()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        // Buat data dummy yang aktif (updated dalam 30 hari terakhir)
+        Pbb::factory()->create([
+            'nama_desa' => 'Desa Aktif',
+            'updated_at' => Carbon::now()->subDays(5)
+        ]);
+
+        // Buat data dummy yang tidak aktif (lebih dari 30 hari yang lalu)
+        Pbb::factory()->create([
+            'nama_desa' => 'Desa Tidak Aktif',
+            'updated_at' => Carbon::now()->subDays(35)
+        ]);
+
+        $response = $this->get('/pbb/pengguna-aktif', [
+            'HTTP_X-Requested-With' => 'XMLHttpRequest'
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/json');
+
+        $json = $response->json();
+        $this->assertGreaterThanOrEqual(1, count($json['data']));
+
+        // Pastikan hanya data aktif yang muncul (tergantung implementasi controller saat ini)
+        // Jika controller menggunakan where updated_at >= 30 hari
+        $desaNames = collect($json['data'])->pluck('nama_desa')->toArray();
+        $this->assertContains('Desa Aktif', $desaNames);
+        $this->assertNotContains('Desa Tidak Aktif', $desaNames);
+    }
+}


### PR DESCRIPTION
issue https://github.com/OpenSID/pantau/issues/620

<img width="1610" height="727" alt="image" src="https://github.com/user-attachments/assets/48c50e46-94be-48ab-ad39-7ab3d64ab03a" />

## Ringkasan Perubahan
Pull request ini menambahkan fitur halaman **PBB Pengguna Aktif** untuk memantau desa-desa yang aktif menggunakan modul PBB dalam 30 hari terakhir. Fitur ini dibuat dengan merujuk pada implementasi `opendk/kecamatan-aktif`.

## Detail Perubahan
1. **Controller Baru**: Menambahkan `PenggunaAktifPbbController` untuk menangani pengambilan data desa dengan status aktif menggunakan DataTables server-side.
2. **View Baru**: Menambahkan `resources/views/pbb/pengguna_aktif.blade.php` sebagai antarmuka pengguna, lengkap dengan tabel informasi dan filter wilayah (Provinsi, Kabupaten, Kecamatan).
3. **Pendaftaran Route**: Menambahkan route `/pbb/pengguna-aktif` di `routes/web.php` untuk mengakses halaman tersebut melalui grup prefix `pbb`.
4. **Factory & Test**: 
    - Membuat `PbbFactory` untuk memudahkan pembuatan data dummy PBB.
    - Menambahkan `tests/Feature/PenggunaAktifPbbTest.php` untuk memastikan fungsionalitas halaman, akses otorisasi, dan validasi data via AJAX berjalan normal.

## Cara Verifikasi
1. Jalankan `php artisan test --filter PenggunaAktifPbbTest` untuk memastikan semua test lulus (**PASS**).
2. Akses halaman melalui menu sidebar **PBB > Pengguna Aktif** atau via URL `/pbb/pengguna-aktif`.
3. Pastikan data tampil dengan benar dan fitur pengurutan (sorting) serta filter wilayah berfungsi sebagaimana mestinya.
