### PR TITLE
Penyesuaian Trigger Deployment: Mengganti Event Release menjadi Push Branch

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,9 +1,9 @@
 name: Deploy Pantau Rilis Dev with Ansible
 
 on:
-  pull_request:
-    branches: [rilis-dev]
-    types: [closed]
+  push:
+    branches:
+      - rilis-dev
 
 permissions:
   contents: read
@@ -14,7 +14,6 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.event.pull_request.merged == true
     name: Deploy Pantau Rilis Dev to Production Server
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy_rilis.yml
+++ b/.github/workflows/deploy_rilis.yml
@@ -1,8 +1,9 @@
 name: Deploy Pantau Rilis with Ansible
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - master
 
 permissions:
   contents: read
@@ -13,8 +14,6 @@ concurrency:
 
 jobs:
   deploy:
-    # rilis dari branch 'master' & bukan prerelease
-    if: github.event.release.target_commitish == 'master' && github.event.release.prerelease == false
     name: Deploy Pantau Rilis to Production Server
     runs-on: ubuntu-latest
 
@@ -32,4 +31,4 @@ jobs:
           script: |
             set -euo pipefail
             cd ${{ secrets.CICD_SERVER_PATH }}
-            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-pantau-rilis.yml --extra-vars "release_tag=${{ github.event.release.tag_name }}"
+            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-pantau-rilis.yml


### PR DESCRIPTION
## Deskripsi
PR ini mengubah mekanisme pemicu (trigger) pada workflow deployment untuk menggunakan event push ke branch spesifik, menggantikan event release.

Perubahan Terperinci:

**1. Workflow Dev (deploy_dev.yml):**

- Menghapus trigger on: release.
- Menambahkan trigger on: push untuk branch rilis-dev.
- Menyederhanakan job dengan menghapus kondisi if yang redundan (trigger push secara otomatis mencakup pull request yang di-merge ke branch tersebut).
- Menghapus job deploy-prerelease yang sudah tidak diperlukan.

**2. Workflow Rilis (deploy_rilis.yml):**

- Mengganti trigger on: release menjadi on: push untuk branch master.
- Menghapus filter kondisi if yang sebelumnya memeriksa properti objek release (seperti prerelease atau target_commitish).
- Menyederhanakan perintah Ansible dengan menghapus variabel --extra-vars "release_tag=..." karena deployment kini berbasis branch, bukan tag rilis.

**Alasan Perubahan:**

- Menyederhanakan alur CI/CD agar deployment terjadi secara otomatis saat ada pembaruan kode di branch terkait tanpa harus membuat rilis secara manual di GitHub.
- Mempercepat proses feedback loop untuk tim pengembang di lingkungan dev.
- Atas permintaan kolektif untuk standarisasi alur kerja deployment.

## Untuk issue:
- https://github.com/OpenSID/pantau/issues/638