### PR TITLE
🛡️ Batch Dependabot Security Updates - 2026-05-30

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "league/flysystem-aws-s3-v3": "^3.0",
         "maatwebsite/excel": "^3.1",
         "nesbot/carbon": "^2.72",
-        "phpoffice/phpspreadsheet": "^1.29",
+        "phpoffice/phpspreadsheet": "^1.30.4",
         "spatie/laravel-backup": "^8.6",
         "spatie/laravel-permission": "^6.21",
         "yajra/laravel-datatables-oracle": "^10.0"

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     },
     "devDependencies": {
         "@playwright/test": "^1.54.1",
-        "axios": "^0.30",
+        "axios": "^0.31.1",
         "laravel-mix": "^6.0.6",
         "lodash": "^4.17.19",
-        "postcss": "^8.1.14"
+        "postcss": "^8.5.10"
     },
     "overrides": {
         "webpack-dev-server": ">=5.2.1"


### PR DESCRIPTION
# 🛡️ Batch Dependabot Security Updates

**Repo:** OpenSID/pantau
**Date:** 2026-05-30
**PHP Version:** ^8.1
**PHP Extensions:** See database table `php_extensions` for PHP 8.1
**Total Alerts:** 30
**Packages Updated:** 3

## 📦 Composer Updates

| Package | From | To | Type | PHP Req | Status |
|---------|------|-----|------|---------|--------|
| `phpoffice/phpspreadsheet` | ^1.29 | ^1.30.4 | 🟡 minor | N/A | ✅ Updated |

## 📦 npm Updates

| Package | From | To | Type | Status |
|---------|------|-----|------|--------|
| `axios` | ^0.30 | ^0.31.1 | 🟡 minor | ✅ Updated |
| `postcss` | ^8.1.14 | ^8.5.10 | 🟡 minor | ✅ Updated |

> **Note:** npm packages updated in package.json. Run `npm install` to update package-lock.json.

## ⚠️ Warnings

- symfony/polyfill-intl-idn: Not found in composer.json (transitive dependency)
- symfony/yaml: Not found in composer.json (transitive dependency)
- symfony/yaml: Not found in composer.json (transitive dependency)
- symfony/yaml: Not found in composer.json (transitive dependency)
- symfony/mime: Not found in composer.json (transitive dependency)
- symfony/mime: Not found in composer.json (transitive dependency)
- symfony/mailer: Not found in composer.json (transitive dependency)
- symfony/routing: Not found in composer.json (transitive dependency)
- qs: Not found in package.json (transitive dependency)
- uuid: Not found in package.json (transitive dependency)
- webpack-dev-server: Not found in package.json (transitive dependency)
- @babel/plugin-transform-modules-systemjs: Not found in package.json (transitive dependency)
- fast-uri: Not found in package.json (transitive dependency)
- fast-uri: Not found in package.json (transitive dependency)

## 📋 Alert Details

### 🟠 HIGH (11)

| # | Package | Ecosystem | Summary |
|---|---------|-----------|---------|
| [152](https://github.com/OpenSID/pantau/security/dependabot/152) | `axios` | npm | Axios: Prototype Pollution Gadgets - Response Tampering, Data Exfiltration, and Request Hijacking |
| [151](https://github.com/OpenSID/pantau/security/dependabot/151) | `axios` | npm | Axios: Prototype Pollution Gadgets - Response Tampering, Data Exfiltration, and Request Hijacking |
| [142](https://github.com/OpenSID/pantau/security/dependabot/142) | `symfony/mime` | composer | Symfony has Email Header / SMTP Command Injection via CRLF in SymfonyComponentMimeAddress |
| [136](https://github.com/OpenSID/pantau/security/dependabot/136) | `axios` | npm | Axios: Header Injection via Prototype Pollution |
| [135](https://github.com/OpenSID/pantau/security/dependabot/135) | `axios` | npm | Axios: Header Injection via Prototype Pollution |
| [132](https://github.com/OpenSID/pantau/security/dependabot/132) | `@babel/plugin-transform-modules-systemjs` | npm | @babel/plugin-transform-modules-systemjs generates arbitrary code when compiling malicious input |
| [131](https://github.com/OpenSID/pantau/security/dependabot/131) | `fast-uri` | npm | fast-uri vulnerable to host confusion via percent-encoded authority delimiters |
| [130](https://github.com/OpenSID/pantau/security/dependabot/130) | `fast-uri` | npm | fast-uri vulnerable to path traversal via percent-encoded dot segments |
| [124](https://github.com/OpenSID/pantau/security/dependabot/124) | `axios` | npm | Axios: Incomplete Fix for CVE-2025-62718 — NO_PROXY Protection Bypassed via RFC 1122 Loopback Subnet (127.0.0.0/8) in Axios 1.15.0 |
| [119](https://github.com/OpenSID/pantau/security/dependabot/119) | `axios` | npm | Axios: Incomplete Fix for CVE-2025-62718 — NO_PROXY Protection Bypassed via RFC 1122 Loopback Subnet (127.0.0.0/8) in Axios 1.15.0 |
| [116](https://github.com/OpenSID/pantau/security/dependabot/116) | `phpoffice/phpspreadsheet` | composer | PhpSpreadsheet has CPU Denial of Service via Unbounded Row Number in XLSX Row Dimensions |

### 🟡 MEDIUM (13)

| # | Package | Ecosystem | Summary |
|---|---------|-----------|---------|
| [143](https://github.com/OpenSID/pantau/security/dependabot/143) | `symfony/mime` | composer | Symfony has Email Header Injection via Non-Token Characters in Mime Parameter Names |
| [141](https://github.com/OpenSID/pantau/security/dependabot/141) | `symfony/mailer` | composer | Symfony has an Argument Injection in SendmailTransport via Dash-Prefixed Recipient Address |
| [140](https://github.com/OpenSID/pantau/security/dependabot/140) | `symfony/routing` | composer | Symfony has a UrlGenerator Route-Requirement Bypass via Unanchored Regex Alternation → Off-Site //host URL Injection |
| [139](https://github.com/OpenSID/pantau/security/dependabot/139) | `qs` | npm | qs has a remotely triggerable DoS: qs.stringify crashes with TypeError on null/undefined entries in comma-format arrays when encodeValuesOnly is set |
| [138](https://github.com/OpenSID/pantau/security/dependabot/138) | `uuid` | npm | uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided |
| [137](https://github.com/OpenSID/pantau/security/dependabot/137) | `webpack-dev-server` | npm | webpack-dev-server vulnerable to cross-origin source code exposure on non-HTTPS origins |
| [134](https://github.com/OpenSID/pantau/security/dependabot/134) | `axios` | npm | Axios: Authentication Bypass via Prototype Pollution Gadget in `validateStatus` Merge Strategy |
| [133](https://github.com/OpenSID/pantau/security/dependabot/133) | `axios` | npm | Axios: Authentication Bypass via Prototype Pollution Gadget in `validateStatus` Merge Strategy |
| [127](https://github.com/OpenSID/pantau/security/dependabot/127) | `axios` | npm | Axios: no_proxy bypass via IP alias allows SSRF |
| [123](https://github.com/OpenSID/pantau/security/dependabot/123) | `axios` | npm | Axios: XSRF Token Cross-Origin Leakage via Prototype Pollution Gadget in `withXSRFToken` Boolean Coercion |
| [122](https://github.com/OpenSID/pantau/security/dependabot/122) | `axios` | npm | Axios: no_proxy bypass via IP alias allows SSRF |
| [118](https://github.com/OpenSID/pantau/security/dependabot/118) | `axios` | npm | Axios: XSRF Token Cross-Origin Leakage via Prototype Pollution Gadget in `withXSRFToken` Boolean Coercion |
| [117](https://github.com/OpenSID/pantau/security/dependabot/117) | `postcss` | npm | PostCSS has XSS via Unescaped </style> in its CSS Stringify Output |

### 🔵 LOW (6)

| # | Package | Ecosystem | Summary |
|---|---------|-----------|---------|
| [147](https://github.com/OpenSID/pantau/security/dependabot/147) | `symfony/polyfill-intl-idn` | composer | symfony/polyfill-intl-idn: xn-- labels with ASCII-only Punycode payloads are treated as equivalent to their decoded form |
| [146](https://github.com/OpenSID/pantau/security/dependabot/146) | `symfony/yaml` | composer | Symfony's YAML Parser has a ReDoS via Catastrophic Backtracking in Parser::cleanup() Regex |
| [145](https://github.com/OpenSID/pantau/security/dependabot/145) | `symfony/yaml` | composer | Symfony hardened the parser when handling untrusted input |
| [144](https://github.com/OpenSID/pantau/security/dependabot/144) | `symfony/yaml` | composer | Symfony's YAML Parser Vulnerable to Exponential Memory Allocation via Recursive Collection-Alias Expansion ("Billion Laughs") |
| [128](https://github.com/OpenSID/pantau/security/dependabot/128) | `axios` | npm | Axios: Null Byte Injection via Reverse-Encoding in AxiosURLSearchParams |
| [121](https://github.com/OpenSID/pantau/security/dependabot/121) | `axios` | npm | Axios: Null Byte Injection via Reverse-Encoding in AxiosURLSearchParams |

---
🤖 _Auto-generated by Dependabot Monitor_