### PR TITLE
🛡️ Batch Dependabot Security Updates - 2026-06-10

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1307,16 +1307,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.11.0",
+            "version": "7.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b"
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/c987f8ce84b8434fa430795eca0f3430663da72b",
-                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
                 "shasum": ""
             },
             "require": {
@@ -1335,7 +1335,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.4",
+                "guzzlehttp/test-server": "^0.5",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -1415,7 +1415,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.11.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.11.1"
             },
             "funding": [
                 {
@@ -1431,7 +1431,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:40:51+00:00"
+            "time": "2026-06-07T22:54:06+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -6469,16 +6469,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -6530,7 +6530,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -6550,7 +6550,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -6638,16 +6638,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "8339098cae28673c15cce00d80734af0453054e2"
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/8339098cae28673c15cce00d80734af0453054e2",
-                "reference": "8339098cae28673c15cce00d80734af0453054e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
                 "shasum": ""
             },
             "require": {
@@ -6694,7 +6694,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -6714,7 +6714,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:51:48+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3429,9 +3429,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.34",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
-      "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
+      "version": "2.10.35",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
+      "integrity": "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3843,9 +3843,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
       "dev": true,
       "funding": [
         {
@@ -4933,9 +4933,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.368",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz",
-      "integrity": "sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==",
+      "version": "1.5.371",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
+      "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
       "dev": true,
       "license": "ISC"
     },
@@ -8128,9 +8128,9 @@
       }
     },
     "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+      "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8158,9 +8158,9 @@
       }
     },
     "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+      "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9027,9 +9027,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9284,15 +9284,15 @@
       "license": "MIT"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },


### PR DESCRIPTION
# 🛡️ Batch Dependabot Security Updates

**Repo:** OpenSID/pantau
**Date:** 2026-06-10
**PHP Version:** ^8.1
**PHP Extensions:** See database table `php_extensions` for PHP 8.1
**Total Alerts:** 35
**Packages Updated:** 0

## ⚠️ Warnings

- symfony/polyfill-intl-idn: Not found in composer.json (transitive dependency)
- symfony/yaml: Not found in composer.json (transitive dependency)
- symfony/yaml: Not found in composer.json (transitive dependency)
- symfony/yaml: Not found in composer.json (transitive dependency)
- symfony/mime: Not found in composer.json (transitive dependency)
- symfony/mime: Not found in composer.json (transitive dependency)
- symfony/mailer: Not found in composer.json (transitive dependency)
- symfony/routing: Not found in composer.json (transitive dependency)
- qs: Not found in package.json (transitive dependency)
- uuid: Not found in package.json (transitive dependency)
- webpack-dev-server: Not found in package.json (transitive dependency)
- @babel/plugin-transform-modules-systemjs: Not found in package.json (transitive dependency)
- fast-uri: Not found in package.json (transitive dependency)
- fast-uri: Not found in package.json (transitive dependency)
- elliptic: No patched version available

## 📋 Alert Details

### 🟠 HIGH (13)

| # | Package | Ecosystem | Summary |
|---|---------|-----------|---------|
| [152](https://github.com/OpenSID/pantau/security/dependabot/152) | `axios` | npm | Axios: Prototype Pollution Gadgets - Response Tampering, Data Exfiltration, and Request Hijacking |
| [151](https://github.com/OpenSID/pantau/security/dependabot/151) | `axios` | npm | Axios: Prototype Pollution Gadgets - Response Tampering, Data Exfiltration, and Request Hijacking |
| [142](https://github.com/OpenSID/pantau/security/dependabot/142) | `symfony/mime` | composer | Symfony has Email Header / SMTP Command Injection via CRLF in SymfonyComponentMimeAddress |
| [136](https://github.com/OpenSID/pantau/security/dependabot/136) | `axios` | npm | Axios: Header Injection via Prototype Pollution |
| [135](https://github.com/OpenSID/pantau/security/dependabot/135) | `axios` | npm | Axios: Header Injection via Prototype Pollution |
| [132](https://github.com/OpenSID/pantau/security/dependabot/132) | `@babel/plugin-transform-modules-systemjs` | npm | @babel/plugin-transform-modules-systemjs generates arbitrary code when compiling malicious input |
| [131](https://github.com/OpenSID/pantau/security/dependabot/131) | `fast-uri` | npm | fast-uri vulnerable to host confusion via percent-encoded authority delimiters |
| [130](https://github.com/OpenSID/pantau/security/dependabot/130) | `fast-uri` | npm | fast-uri vulnerable to path traversal via percent-encoded dot segments |
| [124](https://github.com/OpenSID/pantau/security/dependabot/124) | `axios` | npm | Axios: Incomplete Fix for CVE-2025-62718 — NO_PROXY Protection Bypassed via RFC 1122 Loopback Subnet (127.0.0.0/8) in Axios 1.15.0 |
| [119](https://github.com/OpenSID/pantau/security/dependabot/119) | `axios` | npm | Axios: Incomplete Fix for CVE-2025-62718 — NO_PROXY Protection Bypassed via RFC 1122 Loopback Subnet (127.0.0.0/8) in Axios 1.15.0 |
| [116](https://github.com/OpenSID/pantau/security/dependabot/116) | `phpoffice/phpspreadsheet` | composer | PhpSpreadsheet has CPU Denial of Service via Unbounded Row Number in XLSX Row Dimensions |
| [157](https://github.com/OpenSID/pantau/security/dependabot/157) | `axios` | npm | Axios: Proxy-Authorization header leaks to redirect target when proxy is re-evaluated to direct connection |
| [156](https://github.com/OpenSID/pantau/security/dependabot/156) | `axios` | npm | Axios: Proxy-Authorization header leaks to redirect target when proxy is re-evaluated to direct connection |

### 🟡 MEDIUM (15)

| # | Package | Ecosystem | Summary |
|---|---------|-----------|---------|
| [143](https://github.com/OpenSID/pantau/security/dependabot/143) | `symfony/mime` | composer | Symfony has Email Header Injection via Non-Token Characters in Mime Parameter Names |
| [141](https://github.com/OpenSID/pantau/security/dependabot/141) | `symfony/mailer` | composer | Symfony has an Argument Injection in SendmailTransport via Dash-Prefixed Recipient Address |
| [140](https://github.com/OpenSID/pantau/security/dependabot/140) | `symfony/routing` | composer | Symfony has a UrlGenerator Route-Requirement Bypass via Unanchored Regex Alternation → Off-Site //host URL Injection |
| [139](https://github.com/OpenSID/pantau/security/dependabot/139) | `qs` | npm | qs has a remotely triggerable DoS: qs.stringify crashes with TypeError on null/undefined entries in comma-format arrays when encodeValuesOnly is set |
| [138](https://github.com/OpenSID/pantau/security/dependabot/138) | `uuid` | npm | uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided |
| [137](https://github.com/OpenSID/pantau/security/dependabot/137) | `webpack-dev-server` | npm | webpack-dev-server vulnerable to cross-origin source code exposure on non-HTTPS origins |
| [134](https://github.com/OpenSID/pantau/security/dependabot/134) | `axios` | npm | Axios: Authentication Bypass via Prototype Pollution Gadget in `validateStatus` Merge Strategy |
| [133](https://github.com/OpenSID/pantau/security/dependabot/133) | `axios` | npm | Axios: Authentication Bypass via Prototype Pollution Gadget in `validateStatus` Merge Strategy |
| [127](https://github.com/OpenSID/pantau/security/dependabot/127) | `axios` | npm | Axios: no_proxy bypass via IP alias allows SSRF |
| [123](https://github.com/OpenSID/pantau/security/dependabot/123) | `axios` | npm | Axios: XSRF Token Cross-Origin Leakage via Prototype Pollution Gadget in `withXSRFToken` Boolean Coercion |
| [122](https://github.com/OpenSID/pantau/security/dependabot/122) | `axios` | npm | Axios: no_proxy bypass via IP alias allows SSRF |
| [118](https://github.com/OpenSID/pantau/security/dependabot/118) | `axios` | npm | Axios: XSRF Token Cross-Origin Leakage via Prototype Pollution Gadget in `withXSRFToken` Boolean Coercion |
| [117](https://github.com/OpenSID/pantau/security/dependabot/117) | `postcss` | npm | PostCSS has XSS via Unescaped </style> in its CSS Stringify Output |
| [154](https://github.com/OpenSID/pantau/security/dependabot/154) | `axios` | npm | axios has DoS & Header Injection via Prototype Pollution Read-Side Gadgets in axios merge functions |
| [153](https://github.com/OpenSID/pantau/security/dependabot/153) | `axios` | npm | axios has DoS & Header Injection via Prototype Pollution Read-Side Gadgets in axios merge functions |

### 🔵 LOW (7)

| # | Package | Ecosystem | Summary |
|---|---------|-----------|---------|
| [147](https://github.com/OpenSID/pantau/security/dependabot/147) | `symfony/polyfill-intl-idn` | composer | symfony/polyfill-intl-idn: xn-- labels with ASCII-only Punycode payloads are treated as equivalent to their decoded form |
| [146](https://github.com/OpenSID/pantau/security/dependabot/146) | `symfony/yaml` | composer | Symfony's YAML Parser has a ReDoS via Catastrophic Backtracking in Parser::cleanup() Regex |
| [145](https://github.com/OpenSID/pantau/security/dependabot/145) | `symfony/yaml` | composer | Symfony hardened the parser when handling untrusted input |
| [144](https://github.com/OpenSID/pantau/security/dependabot/144) | `symfony/yaml` | composer | Symfony's YAML Parser Vulnerable to Exponential Memory Allocation via Recursive Collection-Alias Expansion ("Billion Laughs") |
| [128](https://github.com/OpenSID/pantau/security/dependabot/128) | `axios` | npm | Axios: Null Byte Injection via Reverse-Encoding in AxiosURLSearchParams |
| [121](https://github.com/OpenSID/pantau/security/dependabot/121) | `axios` | npm | Axios: Null Byte Injection via Reverse-Encoding in AxiosURLSearchParams |
| [59](https://github.com/OpenSID/pantau/security/dependabot/59) | `elliptic` | npm | Elliptic Uses a Cryptographic Primitive with a Risky Implementation |

---
🤖 _Auto-generated by Dependabot Monitor_