### PR TITLE
🛡️ Batch Dependabot Security Updates - 2026-06-14

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1635,16 +1635,16 @@
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.6",
+            "version": "v1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946"
+                "reference": "7fe811c23a9e3cd712b4389eaeb50b5456d8c529"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/eef7f87bab6f204eba3c39224d8075c70c637946",
-                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/7fe811c23a9e3cd712b4389eaeb50b5456d8c529",
+                "reference": "7fe811c23a9e3cd712b4389eaeb50b5456d8c529",
                 "shasum": ""
             },
             "require": {
@@ -1701,7 +1701,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.6"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.7"
             },
             "funding": [
                 {
@@ -1717,7 +1717,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T22:00:21+00:00"
+            "time": "2026-06-12T21:33:43+00:00"
         },
         {
             "name": "jeroennoten/laravel-adminlte",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3429,9 +3429,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.36",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.36.tgz",
-      "integrity": "sha512-lVq/Df7LXlO79MVaaUHztSwWiG9oXoWHlgvNS51v8Dpd4+G4/VIy6qYePTw31nAVls33nUtnfezYeLkYAak9dg==",
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5528,17 +5528,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -8746,9 +8746,9 @@
       "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
-      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.2.tgz",
+      "integrity": "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -10456,9 +10456,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
-      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
+      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
# 🛡️ Batch Dependabot Security Updates

**Repo:** OpenSID/pantau
**Date:** 2026-06-14
**PHP Version:** ^8.1
**PHP Extensions:** See database table `php_extensions` for PHP 8.1
**Total Alerts:** 35
**Packages Updated:** 0

## ⚠️ Warnings

- symfony/polyfill-intl-idn: Not found in composer.json (transitive dependency)
- symfony/yaml: Not found in composer.json (transitive dependency)
- symfony/yaml: Not found in composer.json (transitive dependency)
- symfony/yaml: Not found in composer.json (transitive dependency)
- symfony/mime: Not found in composer.json (transitive dependency)
- symfony/mime: Not found in composer.json (transitive dependency)
- symfony/mailer: Not found in composer.json (transitive dependency)
- symfony/routing: Not found in composer.json (transitive dependency)
- qs: Not found in package.json (transitive dependency)
- uuid: Not found in package.json (transitive dependency)
- webpack-dev-server: Not found in package.json (transitive dependency)
- @babel/plugin-transform-modules-systemjs: Not found in package.json (transitive dependency)
- fast-uri: Not found in package.json (transitive dependency)
- fast-uri: Not found in package.json (transitive dependency)
- elliptic: No patched version available

## 📋 Alert Details

### 🟠 HIGH (13)

| # | Package | Ecosystem | Summary |
|---|---------|-----------|---------|
| [152](https://github.com/OpenSID/pantau/security/dependabot/152) | `axios` | npm | Axios: Prototype Pollution Gadgets - Response Tampering, Data Exfiltration, and Request Hijacking |
| [151](https://github.com/OpenSID/pantau/security/dependabot/151) | `axios` | npm | Axios: Prototype Pollution Gadgets - Response Tampering, Data Exfiltration, and Request Hijacking |
| [142](https://github.com/OpenSID/pantau/security/dependabot/142) | `symfony/mime` | composer | Symfony has Email Header / SMTP Command Injection via CRLF in SymfonyComponentMimeAddress |
| [136](https://github.com/OpenSID/pantau/security/dependabot/136) | `axios` | npm | Axios: Header Injection via Prototype Pollution |
| [135](https://github.com/OpenSID/pantau/security/dependabot/135) | `axios` | npm | Axios: Header Injection via Prototype Pollution |
| [132](https://github.com/OpenSID/pantau/security/dependabot/132) | `@babel/plugin-transform-modules-systemjs` | npm | @babel/plugin-transform-modules-systemjs generates arbitrary code when compiling malicious input |
| [131](https://github.com/OpenSID/pantau/security/dependabot/131) | `fast-uri` | npm | fast-uri vulnerable to host confusion via percent-encoded authority delimiters |
| [130](https://github.com/OpenSID/pantau/security/dependabot/130) | `fast-uri` | npm | fast-uri vulnerable to path traversal via percent-encoded dot segments |
| [124](https://github.com/OpenSID/pantau/security/dependabot/124) | `axios` | npm | Axios: Incomplete Fix for CVE-2025-62718 — NO_PROXY Protection Bypassed via RFC 1122 Loopback Subnet (127.0.0.0/8) in Axios 1.15.0 |
| [119](https://github.com/OpenSID/pantau/security/dependabot/119) | `axios` | npm | Axios: Incomplete Fix for CVE-2025-62718 — NO_PROXY Protection Bypassed via RFC 1122 Loopback Subnet (127.0.0.0/8) in Axios 1.15.0 |
| [116](https://github.com/OpenSID/pantau/security/dependabot/116) | `phpoffice/phpspreadsheet` | composer | PhpSpreadsheet has CPU Denial of Service via Unbounded Row Number in XLSX Row Dimensions |
| [157](https://github.com/OpenSID/pantau/security/dependabot/157) | `axios` | npm | Axios: Proxy-Authorization header leaks to redirect target when proxy is re-evaluated to direct connection |
| [156](https://github.com/OpenSID/pantau/security/dependabot/156) | `axios` | npm | Axios: Proxy-Authorization header leaks to redirect target when proxy is re-evaluated to direct connection |

### 🟡 MEDIUM (15)

| # | Package | Ecosystem | Summary |
|---|---------|-----------|---------|
| [143](https://github.com/OpenSID/pantau/security/dependabot/143) | `symfony/mime` | composer | Symfony has Email Header Injection via Non-Token Characters in Mime Parameter Names |
| [141](https://github.com/OpenSID/pantau/security/dependabot/141) | `symfony/mailer` | composer | Symfony has an Argument Injection in SendmailTransport via Dash-Prefixed Recipient Address |
| [140](https://github.com/OpenSID/pantau/security/dependabot/140) | `symfony/routing` | composer | Symfony has a UrlGenerator Route-Requirement Bypass via Unanchored Regex Alternation → Off-Site //host URL Injection |
| [139](https://github.com/OpenSID/pantau/security/dependabot/139) | `qs` | npm | qs has a remotely triggerable DoS: qs.stringify crashes with TypeError on null/undefined entries in comma-format arrays when encodeValuesOnly is set |
| [138](https://github.com/OpenSID/pantau/security/dependabot/138) | `uuid` | npm | uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided |
| [137](https://github.com/OpenSID/pantau/security/dependabot/137) | `webpack-dev-server` | npm | webpack-dev-server vulnerable to cross-origin source code exposure on non-HTTPS origins |
| [134](https://github.com/OpenSID/pantau/security/dependabot/134) | `axios` | npm | Axios: Authentication Bypass via Prototype Pollution Gadget in `validateStatus` Merge Strategy |
| [133](https://github.com/OpenSID/pantau/security/dependabot/133) | `axios` | npm | Axios: Authentication Bypass via Prototype Pollution Gadget in `validateStatus` Merge Strategy |
| [127](https://github.com/OpenSID/pantau/security/dependabot/127) | `axios` | npm | Axios: no_proxy bypass via IP alias allows SSRF |
| [123](https://github.com/OpenSID/pantau/security/dependabot/123) | `axios` | npm | Axios: XSRF Token Cross-Origin Leakage via Prototype Pollution Gadget in `withXSRFToken` Boolean Coercion |
| [122](https://github.com/OpenSID/pantau/security/dependabot/122) | `axios` | npm | Axios: no_proxy bypass via IP alias allows SSRF |
| [118](https://github.com/OpenSID/pantau/security/dependabot/118) | `axios` | npm | Axios: XSRF Token Cross-Origin Leakage via Prototype Pollution Gadget in `withXSRFToken` Boolean Coercion |
| [117](https://github.com/OpenSID/pantau/security/dependabot/117) | `postcss` | npm | PostCSS has XSS via Unescaped </style> in its CSS Stringify Output |
| [154](https://github.com/OpenSID/pantau/security/dependabot/154) | `axios` | npm | axios has DoS & Header Injection via Prototype Pollution Read-Side Gadgets in axios merge functions |
| [153](https://github.com/OpenSID/pantau/security/dependabot/153) | `axios` | npm | axios has DoS & Header Injection via Prototype Pollution Read-Side Gadgets in axios merge functions |

### 🔵 LOW (7)

| # | Package | Ecosystem | Summary |
|---|---------|-----------|---------|
| [147](https://github.com/OpenSID/pantau/security/dependabot/147) | `symfony/polyfill-intl-idn` | composer | symfony/polyfill-intl-idn: xn-- labels with ASCII-only Punycode payloads are treated as equivalent to their decoded form |
| [146](https://github.com/OpenSID/pantau/security/dependabot/146) | `symfony/yaml` | composer | Symfony's YAML Parser has a ReDoS via Catastrophic Backtracking in Parser::cleanup() Regex |
| [145](https://github.com/OpenSID/pantau/security/dependabot/145) | `symfony/yaml` | composer | Symfony hardened the parser when handling untrusted input |
| [144](https://github.com/OpenSID/pantau/security/dependabot/144) | `symfony/yaml` | composer | Symfony's YAML Parser Vulnerable to Exponential Memory Allocation via Recursive Collection-Alias Expansion ("Billion Laughs") |
| [128](https://github.com/OpenSID/pantau/security/dependabot/128) | `axios` | npm | Axios: Null Byte Injection via Reverse-Encoding in AxiosURLSearchParams |
| [121](https://github.com/OpenSID/pantau/security/dependabot/121) | `axios` | npm | Axios: Null Byte Injection via Reverse-Encoding in AxiosURLSearchParams |
| [59](https://github.com/OpenSID/pantau/security/dependabot/59) | `elliptic` | npm | Elliptic Uses a Cryptographic Primitive with a Risky Implementation |

---
🤖 _Auto-generated by Dependabot Monitor_