### PR TITLE
Sinkronisasi Perhitungan dan Tampilan Jumlah Desa Aktif Online antara Dashboard dan OpenSID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ QWEN.md
 .kilocode
 .qwen
 /template_ai/
+docs/

--- a/app/Models/Desa.php
+++ b/app/Models/Desa.php
@@ -101,8 +101,7 @@ class Desa extends Model
 
         return $query
             ->selectRaw('count(id) as desa_total')
-            ->selectRaw("(select count(id) from desa as x where x.versi_lokal <> '' and x.versi_hosting is null and coalesce(x.tgl_akses_lokal, 0) >= now() - interval 7 day {$states} {$filterWilayah})  desa_offline")
-            ->selectRaw("(select count(id) from desa as x where x.versi_hosting <> '' and greatest(coalesce(x.tgl_akses_lokal, 0), coalesce(x.tgl_akses_hosting, 0)) >= now() - interval 7 day {$states} {$filterWilayah}) desa_online")
+            ->selectRaw("(select count(id) from desa as x where x.versi_lokal <> '' and x.versi_hosting is null and coalesce(x.tgl_akses_lokal, 0) >= DATE(now() - interval 6 day) {$states} {$filterWilayah})  desa_offline")
             ->selectRaw('count(distinct kode_kabupaten) as kabupaten_total')
             ->selectRaw("(select count(distinct x.kode_kabupaten) from desa as x where (x.versi_hosting like '{$version}-premium%' or x.versi_lokal like '{$version}-premium%') {$states} {$filterWilayah}) as kabupaten_premium")
             ->selectRaw("(select count(distinct x.kode_kabupaten) from desa as x where x.versi_lokal <> '' {$states} {$filterWilayah}) kabupaten_offline")
@@ -124,6 +123,18 @@ class Desa extends Model
                         ) between ? and ?
                         {$states} {$filterWilayah}
                     ) as aktif
+                    ", [$start, $end])
+                    ->selectRaw("
+                    (
+                        select count(id)
+                        from desa as x
+                        where x.versi_hosting <> ''
+                        and greatest(
+                            coalesce(x.tgl_akses_lokal, '1970-01-01 00:00:00'),
+                            coalesce(x.tgl_akses_hosting, '1970-01-01 00:00:00')
+                        ) between ? and ?
+                        {$states} {$filterWilayah}
+                    ) as desa_online
                     ", [$start, $end]);
                 }
             }, function ($query) use ($states, $filterWilayah) {
@@ -134,9 +145,21 @@ class Desa extends Model
                     where greatest(
                         coalesce(x.tgl_akses_lokal, '1970-01-01 00:00:00'),
                         coalesce(x.tgl_akses_hosting, '1970-01-01 00:00:00')
-                    ) >= now() - interval 7 day
+                    ) >= DATE(now() - interval 6 day)
                     {$states} {$filterWilayah}
                 ) as aktif
+                ")
+                ->selectRaw("
+                (
+                    select count(id)
+                    from desa as x
+                    where x.versi_hosting <> ''
+                    and greatest(
+                        coalesce(x.tgl_akses_lokal, '1970-01-01 00:00:00'),
+                        coalesce(x.tgl_akses_hosting, '1970-01-01 00:00:00')
+                    ) >= DATE(now() - interval 6 day)
+                    {$states} {$filterWilayah}
+                ) as desa_online
                 ");
             })
             ->when($provinsi, function ($query, $provinsi) {

--- a/resources/views/website/opensid.blade.php
+++ b/resources/views/website/opensid.blade.php
@@ -318,7 +318,7 @@
                     params.nama_kecamatan = $('#kecamatan option:selected').text();
                     const linkUrl = '{{ url('web/opensid-data') }}?' + new URLSearchParams(params).toString();
                     
-                    $('#desa_aktif').html(`<a href="` + linkUrl + `">` + data.aktif + `</a>`)                    
+                    $('#desa_aktif').html(`<a href="` + linkUrl + `">` + data.desa_online + `</a>`)                    
                     $('#total_desa').text(data.desa_total)
                     $('#filter-label').text(`${params.period}`)
                 }, 'json')


### PR DESCRIPTION
issue # https://github.com/OpenSID/pantau/issues/698

## 🎯 Deskripsi

Pull request ini memperbaiki inkonsistensi jumlah data desa aktif yang ditampilkan pada kartu informasi "Desa Aktif Online" di halaman `/dashboard` dengan elemen "Desa / Kelurahan Aktif" di halaman `/web/opensid`. Sebelumnya, `/web/opensid` menampilkan total seluruh desa aktif (gabungan online dan offline) sedangkan `/dashboard` hanya desa yang hosting (online).

Selisih perhitungan lainnya disebabkan oleh perbedaan definisi "7 Hari Terakhir". Filter bawaan daterangepicker menghitung dari tengah malam pada 6 hari yang lalu (kalender 7 hari penuh), sedangkan query bawaan *dashboard* menghitung rolling secara akurat dari titik 7x24 jam (`NOW() - INTERVAL 7 DAY`). 

Untuk menyamakan data tersebut dan mendukung fungsionalitas pemfilteran secara akurat, dilakukan penyesuaian pemanggilan *field* dari *Javascript*, perbaikan filter periode pada *scope* Eloquent, serta standarisasi fungsi tanggal pada model `Desa`.

---

## 🛠️ Perubahan yang Dilakukan

### 1. `resources/views/website/opensid.blade.php`

**Fix — Koreksi variabel respon API untuk jumlah Desa Aktif:**

- Mengubah pemanggilan *field* pada manipulasi DOM `$('#desa_aktif')` dari `data.aktif` (semua desa aktif) menjadi `data.desa_online` agar selaras dengan data "Desa Aktif Online" di *dashboard*.

```diff
- $('#desa_aktif').html(`<a href="` + linkUrl + `">` + data.aktif + `</a>`)
+ $('#desa_aktif').html(`<a href="` + linkUrl + `">` + data.desa_online + `</a>`)
```

---

### 2. `app/Models/Desa.php`

**Fix — Penyesuaian Query `desa_online` dan Standarisasi Filter Waktu pada Scope `jumlahDesa`:**

- Memindahkan query perhitungan `desa_online` agar dieksekusi di dalam rentang filter `$request->period` layaknya perhitungan `aktif`. 
- Menyesuaikan batas perhitungan rentang waktu *default* tanpa *period request*. Mengganti dari `now() - interval 7 day` menjadi `DATE(now() - interval 6 day)` pada *field* `desa_offline`, `aktif`, dan `desa_online`. Perubahan ini menyelaraskan perhitungan default query (rolling rentang waktu) agar tepat sesuai dengan parameter interval 7 hari pada daterangepicker.

```diff
- ->selectRaw("(select count(id) from desa as x where x.versi_lokal <> '' and x.versi_hosting is null and coalesce(x.tgl_akses_lokal, 0) >= now() - interval 7 day {$states} {$filterWilayah})  desa_offline")
+ ->selectRaw("(select count(id) from desa as x where x.versi_lokal <> '' and x.versi_hosting is null and coalesce(x.tgl_akses_lokal, 0) >= DATE(now() - interval 6 day) {$states} {$filterWilayah})  desa_offline")
```
*(Dan hal yang sama juga diterapkan pada default query untuk `aktif` dan `desa_online`)*

## Screenshot
<img width="558" height="387" alt="image" src="https://github.com/user-attachments/assets/d9701bd3-6f1a-49f5-a482-3902dbdb3ef2" />

<img width="535" height="307" alt="image" src="https://github.com/user-attachments/assets/6b11e7e3-b297-4c77-8022-68804e27371f" />
