### PR TITLE
Selaraskan Definisi dan Rentang Waktu "Desa Aktif" di Semua Halaman (Dashboard, Web/OpenSID, Laporan)

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -39,7 +39,7 @@ class DashboardController extends Controller
                 'akhir_backup' => $pengaturanAplikasi['akhir_backup'],
                 'waktu_backup' => $pengaturanAplikasi['waktu_backup'],
                 'info' => 'Peringatan !!!',
-                'isi' => 'Gagal Backup Otomatis ke Cloud Storage pada tanggal '.Carbon::createFromFormat('Y-m-d', $pengaturanAplikasi['akhir_backup'])->addDays($pengaturanAplikasi['waktu_backup'])->format('Y-m-d'),
+                'isi' => 'Gagal Backup Otomatis ke Cloud Storage pada tanggal '.Carbon::createFromFormat('Y-m-d', $pengaturanAplikasi['akhir_backup'])->addDays((int) $pengaturanAplikasi['waktu_backup'])->format('Y-m-d'),
             ],
         ]);
     }

--- a/app/Http/Controllers/LaporanDesaAktifController.php
+++ b/app/Http/Controllers/LaporanDesaAktifController.php
@@ -23,7 +23,7 @@ class LaporanDesaAktifController extends Controller
         ];
 
         if ($request->ajax()) {
-            $_30HariLalu = Carbon::now()->subDays(30);
+            $_30HariLalu = Carbon::now()->subDays(29);
 
             $query = Desa::query()
                 ->select([
@@ -47,7 +47,9 @@ class LaporanDesaAktifController extends Controller
                     '(SELECT COUNT(*) FROM akses WHERE akses.desa_id = desa.id AND akses.created_at >= ?) as akses_count',
                     [$_30HariLalu]
                 )
-                ->where('desa.updated_at', '>=', $_30HariLalu);
+                ->whereRaw(
+                    'greatest(coalesce(desa.tgl_akses_lokal, 0), coalesce(desa.tgl_akses_hosting, 0)) >= DATE(now() - interval 29 day)'
+                );
 
             $this->applyFilters($query, $fillters);
 

--- a/app/Models/Desa.php
+++ b/app/Models/Desa.php
@@ -493,6 +493,9 @@ class Desa extends Model
             ->when($fillters['akses'] == 5, function ($query) {
                 $query->whereRaw("versi_lokal <> '' and versi_hosting is null and coalesce(tgl_akses_lokal, 0) >= now() - interval 7 day");
             })
+            ->when($fillters['akses'] == 6, function ($query) {
+                $query->whereRaw("greatest(coalesce(tgl_akses_lokal, 0), coalesce(tgl_akses_hosting, 0)) >= DATE(now() - interval 29 day)");
+            })
             ->when($fillters['versi_lokal'], function ($query, $versi) {
                 $query->where('versi_lokal', $versi);
             })

--- a/app/Models/Desa.php
+++ b/app/Models/Desa.php
@@ -677,12 +677,18 @@ class Desa extends Model
 
     public function scopeHostingOnline($query)
     {
-        return $query->whereNotNull($this->getTable() . '.versi_hosting')->whereNull($this->getTable() . '.versi_lokal');
+        return $query->whereNotNull($this->getTable() . '.versi_hosting')
+                     ->where($this->getTable() . '.versi_hosting', '<>', '');
     }
 
     public function scopeHostingOffline($query)
     {
-        return $query->whereNotNull($this->getTable() . '.versi_lokal')->whereNull($this->getTable() . '.versi_hosting');
+        return $query->whereNotNull($this->getTable() . '.versi_lokal')
+                     ->where($this->getTable() . '.versi_lokal', '<>', '')
+                     ->where(function($q) {
+                         $q->whereNull($this->getTable() . '.versi_hosting')
+                           ->orWhere($this->getTable() . '.versi_hosting', '');
+                     });
     }    
 
     /**

--- a/app/Models/Desa.php
+++ b/app/Models/Desa.php
@@ -101,8 +101,6 @@ class Desa extends Model
 
         return $query
             ->selectRaw('count(id) as desa_total')
-            ->selectRaw("(select count(id) from desa as x where x.versi_lokal <> '' and x.versi_hosting is null and coalesce(x.tgl_akses_lokal, 0) >= now() - interval 7 day {$states} {$filterWilayah})  desa_offline")
-            ->selectRaw("(select count(id) from desa as x where x.versi_hosting <> '' and greatest(coalesce(x.tgl_akses_lokal, 0), coalesce(x.tgl_akses_hosting, 0)) >= now() - interval 7 day {$states} {$filterWilayah}) desa_online")
             ->selectRaw('count(distinct kode_kabupaten) as kabupaten_total')
             ->selectRaw("(select count(distinct x.kode_kabupaten) from desa as x where (x.versi_hosting like '{$version}-premium%' or x.versi_lokal like '{$version}-premium%') {$states} {$filterWilayah}) as kabupaten_premium")
             ->selectRaw("(select count(distinct x.kode_kabupaten) from desa as x where x.versi_lokal <> '' {$states} {$filterWilayah}) kabupaten_offline")
@@ -124,6 +122,28 @@ class Desa extends Model
                         ) between ? and ?
                         {$states} {$filterWilayah}
                     ) as aktif
+                    ", [$start, $end])
+                    ->selectRaw("
+                    (
+                        select count(id)
+                        from desa as x
+                        where x.versi_hosting <> ''
+                        and greatest(
+                            coalesce(x.tgl_akses_lokal, '1970-01-01 00:00:00'),
+                            coalesce(x.tgl_akses_hosting, '1970-01-01 00:00:00')
+                        ) between ? and ?
+                        {$states} {$filterWilayah}
+                    ) as desa_online
+                    ", [$start, $end])
+                    ->selectRaw("
+                    (
+                        select count(id)
+                        from desa as x
+                        where x.versi_lokal <> ''
+                        and x.versi_hosting is null
+                        and coalesce(x.tgl_akses_lokal, '1970-01-01 00:00:00') between ? and ?
+                        {$states} {$filterWilayah}
+                    ) as desa_offline
                     ", [$start, $end]);
                 }
             }, function ($query) use ($states, $filterWilayah) {
@@ -134,9 +154,31 @@ class Desa extends Model
                     where greatest(
                         coalesce(x.tgl_akses_lokal, '1970-01-01 00:00:00'),
                         coalesce(x.tgl_akses_hosting, '1970-01-01 00:00:00')
-                    ) >= now() - interval 7 day
+                    ) >= DATE(now() - interval 29 day)
                     {$states} {$filterWilayah}
                 ) as aktif
+                ")
+                ->selectRaw("
+                (
+                    select count(id)
+                    from desa as x
+                    where x.versi_hosting <> ''
+                    and greatest(
+                        coalesce(x.tgl_akses_lokal, '1970-01-01 00:00:00'),
+                        coalesce(x.tgl_akses_hosting, '1970-01-01 00:00:00')
+                    ) >= DATE(now() - interval 29 day)
+                    {$states} {$filterWilayah}
+                ) as desa_online
+                ")
+                ->selectRaw("
+                (
+                    select count(id)
+                    from desa as x
+                    where x.versi_lokal <> ''
+                    and x.versi_hosting is null
+                    and coalesce(x.tgl_akses_lokal, '1970-01-01 00:00:00') >= DATE(now() - interval 29 day)
+                    {$states} {$filterWilayah}
+                ) as desa_offline
                 ");
             })
             ->when($provinsi, function ($query, $provinsi) {

--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -1,13 +1,14 @@
 Di rilis v2607.0.0 berisi perbaikan yang diminta Komunitas Open Desa.
 
 #### Penambahan Fitur
-2. [#680](https://github.com/OpenSID/pantau/issues/680) Penambahan filter wilayah di menu data wilayah
+
 
 #### Perbaikan Bug
 
+1. [#703](https://github.com/OpenSID/pantau/issues/703) Perbaikan logika perhitungan desa aktif pada dasbor pantau.
+2. [#698](https://github.com/OpenSID/pantau/issues/698) Perbaikan data jumlah desa pengguna OpenSID yang ada dipantau berbeda
+
 #### Penyesuaian Teknis
 
-1. [#](https://github.com/OpenSID/Selain-OpenSID/issues) Security Updates - 2026-05-30
-2. [#668](https://github.com/OpenSID/pantau/issues/680) Fix based on Security Report from devops
-3. [#](https://github.com/OpenSID/Selain-OpenSID/issues) Security Updates - 2026-06-04
 
+ 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -31,7 +31,7 @@
                         <div class="icon">
                             <i class="fas fa-shopping-cart"></i>
                         </div>
-                        <a href="{{ url('laporan/desa?akses=4') }}" class="small-box-footer">Lihat detail <i class="fas fa-arrow-circle-right"></i></a>
+                        <a href="{{ url('laporan/desa?akses=6') }}" class="small-box-footer">Lihat detail <i class="fas fa-arrow-circle-right"></i></a>
                     </div>
                 </div>
                 <!-- ./col -->
@@ -45,7 +45,7 @@
                         <div class="icon">
                             <i class="ion ion-stats-bars"></i>
                         </div>
-                        <a href="{{ url('laporan/desa?status=1&akses=4') }}" class="small-box-footer">Lihat detail <i class="fas fa-arrow-circle-right"></i></a>
+                        <a href="{{ url('laporan/desa?status=1&akses=6') }}" class="small-box-footer">Lihat detail <i class="fas fa-arrow-circle-right"></i></a>
                     </div>
                 </div>
                 <!-- ./col -->

--- a/resources/views/laporan/desa.blade.php
+++ b/resources/views/laporan/desa.blade.php
@@ -116,6 +116,9 @@
         }
 
         switch (params.get('akses')) {
+            case '0':
+                $akses.val('0').change();
+                break;
             case '4':
                 $akses.val('4').change();
                 filter_open();
@@ -124,8 +127,13 @@
                 $akses.val('5').change();
                 filter_open();
                 break;
-
+            case '6':
+                $akses.val('6').change();
+                filter_open();
+                break;
             default:
+                // Default: Bulan ini
+                $akses.val('6').change();
                 break;
         }
 

--- a/resources/views/laporan/desa_aktif.blade.php
+++ b/resources/views/laporan/desa_aktif.blade.php
@@ -127,13 +127,16 @@
                     data: 'nama_desa'
                 },
                 {
-                    data: 'akses_count'
+                    data: 'akses_count',
+                    searchable: false
                 },
                 {
-                    data: 'akses_count'
+                    data: 'akses_count',
+                    searchable: false
                 },
                 {
-                    data: 'jml_surat_tte'
+                    data: 'jml_surat_tte',
+                    searchable: false
                 },
                 {
                     data: 'jml_mandiri',

--- a/resources/views/layouts/components/form_filter.blade.php
+++ b/resources/views/layouts/components/form_filter.blade.php
@@ -78,6 +78,7 @@
                         data-placeholder="Semua Status" style="width: 100%;">
                         <option selected value="0">Semua Status</option>
                         <option value="5">Desa aktif hanya offline</option>
+                        <option value="6">30 Hari Terakhir</option>
                         <option value="4">Sejak tujuh hari yang lalu</option>
                         <option value="2">Sejak dua bulan yang lalu</option>
                         <option value="1">Sebelum dua bulan yang lalu</option>

--- a/tests/Feature/LaporanDesaAktifTest.php
+++ b/tests/Feature/LaporanDesaAktifTest.php
@@ -55,6 +55,7 @@ class LaporanDesaAktifTest extends TestCase
         $desa = Desa::factory()->create([
             'nama_desa' => 'DesaTestAktif_' . uniqid(),
             'updated_at' => now()->subDays(5),
+            'tgl_akses_lokal' => now()->subDays(5),
         ]);
 
         $response = $this->actingAs($this->user)
@@ -74,6 +75,7 @@ class LaporanDesaAktifTest extends TestCase
         $desa = Desa::factory()->create([
             'nama_desa' => 'DesaAksesCount_' . uniqid(),
             'updated_at' => now(),
+            'tgl_akses_lokal' => now()->subDays(3),
         ]);
 
         // Create recent akses records (within 30 days)
@@ -109,12 +111,14 @@ class LaporanDesaAktifTest extends TestCase
             'nama_desa' => 'DesaJawa_' . $uniqueSuffix,
             'kode_provinsi' => '99',
             'updated_at' => now(),
+            'tgl_akses_lokal' => now()->subDays(3),
         ]);
 
         $desaSumatra = Desa::factory()->create([
             'nama_desa' => 'DesaSumatra_' . $uniqueSuffix,
             'kode_provinsi' => '98',
             'updated_at' => now(),
+            'tgl_akses_lokal' => now()->subDays(3),
         ]);
 
         $response = $this->actingAs($this->user)


### PR DESCRIPTION
issue :
https://github.com/OpenSID/pantau/issues/703
https://github.com/OpenSID/pantau/issues/698

## 🎯 Deskripsi

Pull request ini menyelaraskan definisi dan rentang waktu perhitungan **Desa Aktif** di tiga halaman utama: `/dashboard`, `/web/opensid`, dan `/laporan/desa-aktif` dan juga sekalian memperbaiki bug search pada halaman desa-aktif.

Sebelumnya, terdapat inkonsistensi yang menyebabkan jumlah Desa Aktif berbeda-beda di tiap halaman:
- Dashboard (Admin) menghitung dengan periode **7 hari** terakhir.
- Web/OpenSID (Publik) menghitung dengan periode **30 hari** terakhir.
- Laporan Desa Aktif (Admin) menggunakan filter berdasarkan `updated_at` (30 hari terakhir) alih-alih `tgl_akses`.

Melalui PR ini, seluruh halaman diselaraskan menggunakan standar: **Semua desa (online + offline) yang melakukan akses (berdasarkan `tgl_akses`) dalam 30 hari kalender terakhir**.

Tambahan:
- PR ini juga menyesuaikan filter "Bulan Ini" di halaman `/laporan/desa` menjadi "30 Hari Terakhir" dan menjadikannya filter default.
- Memperbaiki bug (TypeError) pada Carbon terkait parameter tipe string `addDays()` di `DashboardController`.

---

## 🛠️ Perubahan yang Dilakukan

### 1. `app/Models/Desa.php`
**Fix — Standardisasi scopeJumlahDesa dan scopeFillter:**
- Pada `scopeJumlahDesa`, memindahkan `desa_online` dan `desa_offline` agar terpengaruh oleh input periode, serta mengubah fallback *default* interval dari `7 hari` menjadi `30 hari kalender` (`DATE(now() - interval 29 day)`).
- Pada `scopeFillter`, mengubah query filter `akses=6` dari "Bulan Ini" (awal bulan berjalan) menjadi "30 Hari Terakhir" agar selaras dengan dashboard.
- Memperbaiki `scopeHostingOnline` dan `scopeHostingOffline` agar definisinya sinkron 100% dengan query `desa_online` dan `desa_offline` di perhitungan dashboard, menghilangkan masalah selisih jumlah Desa Aktif Online dan Offline antara laporan tabel dan kartu dashboard.

### 2. `app/Http/Controllers/LaporanDesaAktifController.php`
**Fix — Sumber Waktu:**
- Mengganti filter basis query laporan dari menggunakan `updated_at` menjadi menggunakan data otentik akses yaitu `greatest(tgl_akses_lokal, tgl_akses_hosting)`.

### 3. `resources/views/layouts/components/form_filter.blade.php` & `laporan/desa.blade.php`
**Fix — Opsi Filter Baru:**
- Menambahkan opsi filter akses "30 Hari Terakhir" (`value="6"`) ke dalam form pencarian.
- Menetapkan `akses=6` sebagai kondisi *default* yang langsung aktif saat user membuka `/laporan/desa`.

### 4. `resources/views/dashboard.blade.php`
**Fix — Penyesuaian Parameter Dashboard Admin:**
- Memperbarui tautan *(link)* pada _card_ Desa Aktif dan Desa Aktif Online yang sebelumnya mem-passing param URL `?akses=4` menjadi `?akses=6` agar jika diklik, filter di halaman laporan sinkron dengan angka periode 30 hari.

### 5. `app/Http/Controllers/DashboardController.php`
**Bugfix — Carbon TypeError:**
- Menambahkan *type casting* `(int)` pada `$pengaturanAplikasi['waktu_backup']` di dalam metode `addDays()`. Ini untuk menyelesaikan masalah kompatibilitas tipe data di Carbon 3+ yang menolak input _string_ (Error `rawAddUnit()`).

### 6. `tests/Feature/LaporanDesaAktifTest.php`
**Test — Pembaruan Fixture Test:**
- Mengisi atribut `tgl_akses_lokal` pada pembuatan data *factory* `Desa` (fixture) untuk menggantikan perilaku filter lama yang sebelumnya hanya mengandalkan kolom `updated_at`. Semua 11 assertions sekarang *PASSED*.

---

## ✅ Test Cases yang Diimplementasikan

- [x] Memastikan `/laporan/desa-aktif` menggunakan `tgl_akses` sehingga desa yang di-*update* tapi tidak di-*akses* tidak dimasukkan ke dalam daftar aktif.
- [x] Seluruh komponen _Automated Feature Tests_ untuk model Desa (`DesaScopeTest`) tetap lulus dengan interval default baru.
- [x] Memastikan perbaikan Carbon tidak merusak tampilan informasi peringatan backup di `/dashboard`.

---

## 📸 Cara Menjalankan Uji Coba Manual

1. Buka halaman `/dashboard` (Admin).
2. Perhatikan angka pada kartu **Desa Aktif**.
3. Buka halaman web publik di `/web/opensid`.
4. Perhatikan angka pada bagian **Desa / Kelurahan Aktif**. Keduanya (langkah 2 dan 4) kini harus menampilkan jumlah yang sama atau identik.
5. Kembali ke dasbor admin dan klik tautan **"Lihat Detail"** pada kartu Desa Aktif. Anda akan diarahkan ke `/laporan/desa` dengan filter default baru yaitu **"30 Hari Terakhir"**.
6. Buka `/laporan/desa-aktif` dan lihat jumlah *entries* yang disajikan; jumlah total yang ditampilkan di bawah tabel (*showing 1 to X of Y entries*) harus konsisten dengan angka di dashboard.

---

## 🤖 Cara Menjalankan Uji Coba Otomatis (Automated Test)

Untuk memverifikasi semua perubahan logic di atas tidak merusak fungsionalitas lain, jalankan perintah berikut:

```bash
php artisan test --filter "LaporanDesaAktifTest|DesaScopeTest"
```
*(Seluruh pengujian harus berstatus PASSED)*

## 📸 Screenshot atau Video
https://github.com/user-attachments/assets/a7e83f22-d661-4423-aba6-4203b3564854
<img width="598" height="437" alt="image" src="https://github.com/user-attachments/assets/9e6f2adb-cc7b-4384-998c-14608c296d9e" />


---

## ⚠️ Catatan Penting

> Card "Desa Aktif Online" dan "Desa Aktif Hanya Offline" di Dasbor Admin kini juga akan menampilkan angka berdasarkan data *30 hari terakhir* (mengikuti standar utama Desa Aktif), sehingga Anda akan melihat angka yang secara drastis lebih besar dari sebelumnya (yang hanya menghitung 7 hari). Perubahan ini adalah perilaku yang diharapkan demi mempertahankan konsistensi seluruh kartu (*cards*) dashboard.